### PR TITLE
Make sure pin is configured as output

### DIFF
--- a/docs/06io/code/gpio_setup.sh
+++ b/docs/06io/code/gpio_setup.sh
@@ -24,6 +24,6 @@ fi
 for pin in $pins
 do
     echo $pin
-    config-pin $pin gpio
+    config-pin $pin out
     config-pin -q $pin
 done


### PR DESCRIPTION
This script didn't for me, since the pin was previously configured as an input. This change will ensure that the pin works as an output.